### PR TITLE
Update appimage-ci.yml

### DIFF
--- a/.github/workflows/appimage-ci.yml
+++ b/.github/workflows/appimage-ci.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Build AppImage
         run: |
           set -euo pipefail
-          curl -L "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-${{ matrix.appimagetool_suffix }}.AppImage" -o appimagetool.AppImage
+          curl -L "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${{ matrix.appimagetool_suffix }}.AppImage" -o appimagetool.AppImage
           chmod +x appimagetool.AppImage
           export APPIMAGE_EXTRACT_AND_RUN=1
           export ARCH=${{ matrix.arch }}


### PR DESCRIPTION
Previous appimagetool may be show this error in modern systems like Fedora 42/43, Ubuntu 22.02 and others

dlopen(): error loading libfuse.so.2

```txt
AppImages require FUSE to run. 
You might still be able to extract the contents of this AppImage  if you run it with the --appimage-extract option.  See https://github.com/AppImage/AppImageKit/wiki/FUSE  for more information
```

You can use this updated tool which does not reproduce the same error.