### PR TITLE
fix: strip BOM from job logs to fix first line timestamp formatting

### DIFF
--- a/src/ui/job_logs_window.rs
+++ b/src/ui/job_logs_window.rs
@@ -574,6 +574,7 @@ struct WorkflowCommand<'a> {
 }
 
 fn split_timestamp(line: &str) -> (Option<&str>, &str) {
+    let line = line.strip_prefix("\u{FEFF}").unwrap_or(line);
     if line.len() < 10 {
         return (None, line);
     }


### PR DESCRIPTION
Fixed the timestamp on the first line of job logs not being formatted correctly (appearing white instead of grey).

The first line of GitHub Action logs often contains a Byte Order Mark (BOM) (`\u{FEFF}`). The `split_timestamp function` was checking if the first 4 characters were digits, but the invisible BOM caused this check to fail for the first line, treating it as a regular log line without a timestamp.

