### PR TITLE
fix: Handle HTTP 410 Gone error for expired job logs

### DIFF
--- a/src/api/error.rs
+++ b/src/api/error.rs
@@ -17,6 +17,6 @@ pub enum GitHubError {
     #[error("Not found")]
     NotFound,
 
-    #[error("Gone")]
+    #[error("Resource no longer available")]
     Gone,
 }

--- a/src/api/error.rs
+++ b/src/api/error.rs
@@ -16,4 +16,7 @@ pub enum GitHubError {
 
     #[error("Not found")]
     NotFound,
+
+    #[error("Gone")]
+    Gone,
 }

--- a/src/api/jobs.rs
+++ b/src/api/jobs.rs
@@ -59,6 +59,8 @@ pub async fn get_job_logs(
         Ok(logs)
     } else if status == StatusCode::NOT_FOUND {
         Err(GitHubError::NotFound)
+    } else if status == StatusCode::GONE {
+        Err(GitHubError::Gone)
     } else if status.is_success() {
         // Accept other success statuses like 202
         let body = response.bytes().await?;

--- a/src/ui/job_logs_window.rs
+++ b/src/ui/job_logs_window.rs
@@ -191,6 +191,15 @@ impl JobLogsWindow {
                     copy_button.set_sensitive(false);
                     save_button.set_sensitive(false);
                 }
+                Err(GitHubError::Gone) => {
+                    warn!("Job logs expired (410 Gone)");
+                    text_view.set_sensitive(false);
+                    text_view.buffer().set_text(
+                        "The logs for this run have expired and are no longer available.",
+                    );
+                    copy_button.set_sensitive(false);
+                    save_button.set_sensitive(false);
+                }
                 Err(e) => {
                     error!("Failed to load logs: {}", e);
                     text_view.set_sensitive(false);
@@ -249,6 +258,15 @@ impl JobLogsWindow {
                         tv_for_ui.set_sensitive(false);
                         tv_for_ui.buffer().set_text(
                             "Logs are not yet available for this job. GitHub only provides logs once the job starts streaming output or completes. Try refreshing in a few moments.",
+                        );
+                        copy_for_result.set_sensitive(false);
+                        save_for_result.set_sensitive(false);
+                    }
+                    Err(GitHubError::Gone) => {
+                        warn!("Job logs expired during refresh (410 Gone)");
+                        tv_for_ui.set_sensitive(false);
+                        tv_for_ui.buffer().set_text(
+                            "The logs for this run have expired and are no longer available.",
                         );
                         copy_for_result.set_sensitive(false);
                         save_for_result.set_sensitive(false);


### PR DESCRIPTION
## Changes Implemented

1.  **`src/api/error.rs`**: Added a `Gone` variant to the `GitHubError` enum to specifically represent the HTTP 410 status.
2.  **`src/api/jobs.rs`**: Updated `get_job_logs` to check for `StatusCode::GONE` and return the new `GitHubError::Gone` error variant.
3.  **`src/ui/job_logs_window.rs`**: Updated the UI logic in both `load_logs` and the refresh button handler. Now, when `GitHubError::Gone` is received, the window displays the user-friendly message: *"The logs for this run have expired and are no longer available."* instead of the generic API error with the pointless "Unable to load logs right now. Please try again later." intro.