### PR TITLE
chore(dependabot): ignore gtk4 0.11.4 (breaks libadwaita 0.9.1)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,14 @@ updates:
       # compiled into the binary. Revisit once keyring 4.x ships stable.
       - dependency-name: rand
         versions: ["0.8.x"]
+      # gtk4 0.11.4 cfg-gated `gtk4::Accessible` behind the `v4_10` feature
+      # (gtk-rs/gtk4-rs#2332). This breaks libadwaita 0.9.1's generated bindings
+      # (which reference `gtk::Accessible` unconditionally) and our own ListItem
+      # factory code, and no compatible libadwaita 0.9.x has been released.
+      # Enabling the `v4_10` feature fixes the libadwaita errors but not ours.
+      # Block this specific version; revisit when 0.11.5+ resolves the gating.
+      - dependency-name: gtk4
+        versions: ["0.11.4"]
       # Block major bumps of gtk-rs-core crates: even with the `gtk-rs` group,
       # Dependabot opens PRs one crate at a time when a co-released peer hasn't
       # also updated, which leaves two versions of shared types in the graph


### PR DESCRIPTION
## Why

Dependabot PR #50 bumped `gtk4` 0.11.3 → 0.11.4. That version **breaks the build**:

```
error[E0425]: cannot find type `Accessible` in crate `gtk`
  --> libadwaita-0.9.1/src/auto/*.rs
```

Root cause: gtk4-rs 0.11.4 cfg-gated `gtk4::Accessible` behind the `v4_10` feature (upstream bug [gtk-rs/gtk4-rs#2332](https://github.com/gtk-rs/gtk4-rs/issues/2332), still open). libadwaita 0.9.1's generated bindings reference `gtk::Accessible` unconditionally, so they no longer compile. No compatible libadwaita 0.9.x has been released (`master` has moved to `0.10.0-alpha`).

Verified locally: enabling the `v4_10` feature fixes the libadwaita errors but our own `ListItem` factory code (`connect_setup`/`connect_bind`) then fails with 14 further errors — so it is **not** a one-line fix. `develop` (0.11.3) compiles cleanly.

## Change

Ignore the specific broken version `gtk4 0.11.4` in `dependabot.yml`. Future 0.11.5+ will still be proposed, at which point the bump can be re-evaluated (likely alongside a `v4_10` minimum). PR #50 will be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)